### PR TITLE
Expose a method to set the security headers on a response

### DIFF
--- a/Sources/VaporSecurityHeaders/VaporSecurityHeaders.swift
+++ b/Sources/VaporSecurityHeaders/VaporSecurityHeaders.swift
@@ -43,10 +43,14 @@ public struct SecurityHeaders: Middleware {
     public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
         let response = try next.respond(to: request)
         
+        setHeaders(response: response)
+        
+        return response
+    }
+    
+    public func setHeaders(response: Response) {
         for spec in configurations {
             spec.setHeader(on: response)
         }
-        
-        return response
     }
 }


### PR DESCRIPTION
I ran into a situation where I wanted to apply the security headers to a response, but then wanted to override one of the header values so I added a public `setHeaders` method.