### PR TITLE
Remove HPKP from Roadmap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ language: generic
 sudo: required
 dist: trusty
 
-osx_image: xcode9
+osx_image: xcode9.1
 before_install:
     - if [ $TRAVIS_OS_NAME == "osx" ]; then
+            brew update;
             brew tap vapor/tap;
             brew update;
             brew install vapor;

--- a/README.md
+++ b/README.md
@@ -96,13 +96,6 @@ You can also build the middleware manually like so:
 let securityHeadersMiddleware = SecurityHeadersFactory().build()
 ```
 
-# Roadmap
-
-The following features are on the roadmap to be implemented:
-
-* Public-Key-Pins (HPKP)
-* Public-Key-Pins-Report-Only
-
 # Server Configuration
 
 ## Vapor
@@ -265,7 +258,3 @@ The different options are:
 * "unsafe-url"
 
 I won't go into details about each one, I will point you in the direction of a far better explanation [by Scott Helme](https://scotthelme.co.uk/a-new-security-header-referrer-policy/).
-
-## Public-Key-Pins
-
-Coming soon


### PR DESCRIPTION
Due to [Chrome deprecating HPKP](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/he9tr7p3rZ8/eNMwKPmUBAAJ) and the fact it isn't supported in any other browsers except Firefox (and the expectation is that they will follow Chrome's lead and deprecate it) I am no longer planning on implementing HPKP. The risks were probably too great and I struggled to come up with a nice solution before the deprecation notice, so it seems like there isn't much point!

I have mentioned the other options for protecting against rogue certs in [my security talk on the Geek's blog](https://geeks.brokenhands.io/blog/posts/security-and-your-vapor-application/). 