### PR TITLE
add X-XSS-Protection report header config

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ To just enable the protection:
 let xssProtectionConfig = XssProtectionConfiguration(option: .enable)
 ```
 
+To sanitize the page and report the violation:
+
+```swift
+let xssProtectionConfig = XssProtectionConfiguration(option: .report("https://report-uri.com"))
+```
+
 Or to disable:
 
 ```swift

--- a/Sources/VaporSecurityHeaders/Configurations/XSSProtectionConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/XSSProtectionConfiguration.swift
@@ -6,6 +6,7 @@ public struct XSSProtectionConfiguration: SecurityHeaderConfiguration {
         case disable
         case enable
         case block
+        case report(uri: String)
     }
 
     private let option: Options
@@ -22,6 +23,8 @@ public struct XSSProtectionConfiguration: SecurityHeaderConfiguration {
             response.headers[HeaderKey.xXssProtection] = "1"
         case .block:
             response.headers[HeaderKey.xXssProtection] = "1; mode=block"
+        case .report(let uri):
+            response.headers[HeaderKey.xXssProtection] = "1; report=\(uri)"
         }
     }
 }

--- a/Tests/VaporSecurityHeadersTests/HeaderTests.swift
+++ b/Tests/VaporSecurityHeadersTests/HeaderTests.swift
@@ -23,6 +23,7 @@ class HeaderTests: XCTestCase {
         ("testHeaderWithXssProtectionDisable", testHeaderWithXssProtectionDisable),
         ("testHeaderWithXssProtectionEnable", testHeaderWithXssProtectionEnable),
         ("testHeaderWithXssProtectionBlock", testHeaderWithXssProtectionBlock),
+        ("testHeaderWithXssProtectionReport", testHeaderWithXssProtectionReport),
         ("testHeaderWithHSTSwithMaxAge", testHeaderWithHSTSwithMaxAge),
         ("testHeadersWithHSTSwithSubdomains", testHeadersWithHSTSwithSubdomains),
         ("testHeadersWithHSTSwithPreload", testHeadersWithHSTSwithPreload),
@@ -212,6 +213,15 @@ class HeaderTests: XCTestCase {
         let response = try drop.respond(to: request)
 
         XCTAssertEqual("1; mode=block", response.headers[HeaderKey.xXssProtection])
+    }
+
+    func testHeaderWithXssProtectionReport() throws {
+        let xssProtectionConfig = XSSProtectionConfiguration(option: .report(uri: "https://test.com"))
+        let factory = SecurityHeadersFactory().with(XSSProtection: xssProtectionConfig)
+        let drop = try makeTestDroplet(securityHeadersToAdd: factory)
+        let response = try drop.respond(to: request)
+
+        XCTAssertEqual("1; report=https://test.com", response.headers[HeaderKey.xXssProtection])
     }
 
     func testHeaderWithHSTSwithMaxAge() throws {


### PR DESCRIPTION
Just added the `X-XSS-Protection: 1; report=<reporting-uri>` config.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection