### PR TITLE
Add Content Security Policy builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,29 @@ The Vapor Security Headers package will set a default CSP of `default-src: 'self
 
 The API default CSP is `default-src: 'none'` as an API should only return data and never be loading scripts or images to display!
 
-You can build a CSP header (`ContentSecurityPolicy`) with the following directives: baseUri(sources), blockAllMixedContent(), connectSrc(sources), defaultSrc(sources), fontSrc(sources), formAction(sources), frameAncestors(sources), frameSrc(sources), imgSrc(sources), manifestSrc(sources), mediaSrc(sources), objectSrc(sources), pluginTypes(types), reportTo(json_object), reportUri(uri), requireSriFor(values), sandbox(values), scriptSrc(sources), styleSrc(sources), upgradeInsecureRequests(), workerSrc(sources)
+You can build a CSP header (`ContentSecurityPolicy`) with the following directives: 
+
+- baseUri(sources)
+- blockAllMixedContent()
+- connectSrc(sources)
+- defaultSrc(sources)
+- fontSrc(sources)
+- formAction(sources)
+- frameAncestors(sources)
+- frameSrc(sources)
+- imgSrc(sources)
+- manifestSrc(sources)
+- mediaSrc(sources)
+- objectSrc(sources)
+- pluginTypes(types)
+- reportTo(json_object)
+- reportUri(uri)
+- requireSriFor(values)
+- sandbox(values)
+- scriptSrc(sources)
+- styleSrc(sources)
+- upgradeInsecureRequests()
+- workerSrc(sources)
 
 *Example:*
 
@@ -123,10 +145,24 @@ let cspConfig = ContentSecurityPolicy()
 Content-Security-Policy: script-src https://static.brokenhands.io; style-src https://static.brokenhands.io; img-src https://static.brokenhands.io
 ```
 
-You can set a custom header with set(value).
+You can set a custom header with ContentSecurityPolicy().set(value) or ContentSecurityPolicyConfiguration(value).
+
+**ContentSecurityPolicy().set(value)**
 
 ```swift
-ContentSecurityPolicy().set(value: "default-src: 'none'")
+let cspBuilder = ContentSecurityPolicy().set(value: "default-src: 'none'")
+
+let cspConfig = ContentSecurityPolicyConfiguration(value: cspBuilder)
+
+let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: cspConfig)
+```
+
+**ContentSecurityPolicyConfiguration(value)**
+
+```swift
+let cspConfig = ContentSecurityPolicyConfiguration(value: "default-src 'none'")
+
+let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: cspConfig)
 ```
 
 ```http
@@ -178,7 +214,7 @@ See [Google Developers - The Reporting API](https://developers.google.com/web/up
 To configure your CSP you can add it to your `ContentSecurityPolicyConfiguration` like so:
 
 ```swift
-let cspConfig = ContentSecurityPolicy()
+let cspBuilder = ContentSecurityPolicy()
         .defaultSrc(sources: CSPKeywords.none)
         .scriptSrc(sources: "https://static.brokenhands.io")
         .styleSrc(sources: "https://static.brokenhands.io")
@@ -190,7 +226,9 @@ let cspConfig = ContentSecurityPolicy()
         .blockAllMixedContent()
         .requireSriFor(values: "script", "style")
         .reportUri(uri: "https://csp-report.brokenhands.io")
-        
+
+let cspConfig = ContentSecurityPolicyConfiguration(value: cspBuilder)
+
 let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: cspConfig)
 ```
 

--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -41,24 +41,36 @@ extension Request {
 }
 
 public struct CSPReportTo: Codable {
-    var group: String?
-    var max_age: Int
-    var endpoints: [CSPReportToEndpoint]
-    var include_subdomains: Bool?
+    private let group: String?
+    private let max_age: Int
+    private let endpoints: [CSPReportToEndpoint]
+    private let include_subdomains: Bool?
+
+    public init(group: String? = nil, max_age: Int,
+                endpoints: [CSPReportToEndpoint], include_subdomains: Bool? = nil) {
+        self.group = group
+        self.max_age = max_age
+        self.endpoints = endpoints
+        self.include_subdomains = include_subdomains
+    }
 }
 
 public struct CSPReportToEndpoint: Codable {
-    var url: String
+    private let url: String
+
+    public init(url: String) {
+        self.url = url
+    }
 }
 
 public struct CSPKeywords {
-    static let all = "*"
-    static let none = "'none'"
-    static let `self` = "'self'"
-    static let strictDynamic = "'strict-dynamic'"
-    static let unsafeEval = "'unsafe-eval'"
-    static let unsafeHashedAttributes = "'unsafe-hashed-attributes'"
-    static let unsafeInline = "'unsafe-inline'"
+    public static let all = "*"
+    public static let none = "'none'"
+    public static let `self` = "'self'"
+    public static let strictDynamic = "'strict-dynamic'"
+    public static let unsafeEval = "'unsafe-eval'"
+    public static let unsafeHashedAttributes = "'unsafe-hashed-attributes'"
+    public static let unsafeInline = "'unsafe-inline'"
 }
 
 public class ContentSecurityPolicy {

--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -1,11 +1,12 @@
 import Vapor
+import Foundation
 
 public struct ContentSecurityPolicyConfiguration: SecurityHeaderConfiguration {
 
     private let value: String
 
-    public init(value: String) {
-        self.value = value
+    public init(value: ContentSecurityPolicy) {
+        self.value = value.value
     }
 
     func setHeader(on response: Response, from request: Request) {
@@ -36,5 +37,147 @@ extension Request {
                 requestConfig.configuration = newValue
             }
         }
+    }
+}
+
+public struct CSPReportTo: Codable {
+    var group: String?
+    var max_age: Int
+    var endpoints: [CSPReportToEndpoint]
+    var include_subdomains: Bool?
+}
+
+public struct CSPReportToEndpoint: Codable {
+    var url: String
+}
+
+public struct CSPKeywords {
+    static let all = "*"
+    static let none = "'none'"
+    static let `self` = "'self'"
+    static let strictDynamic = "'strict-dynamic'"
+    static let unsafeEval = "'unsafe-eval'"
+    static let unsafeHashedAttributes = "'unsafe-hashed-attributes'"
+    static let unsafeInline = "'unsafe-inline'"
+}
+
+public class ContentSecurityPolicy {
+    private var policy: [String] = []
+
+    var value: String {
+        return policy.joined(separator: "; ")
+    }
+
+    func set(value: String) -> ContentSecurityPolicy {
+        policy.append(value)
+        return self
+    }
+
+    func baseUri(sources: String...) -> ContentSecurityPolicy {
+        policy.append("base-uri \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func blockAllMixedContent() -> ContentSecurityPolicy {
+        policy.append("block-all-mixed-content")
+        return self
+    }
+
+    func connectSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("connect-src \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func defaultSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("default-src \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func fontSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("font-src \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func formAction(sources: String...) -> ContentSecurityPolicy {
+        policy.append("form-action \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func frameAncestors(sources: String...) -> ContentSecurityPolicy {
+        policy.append("frame-ancestors \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func frameSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("frame-src \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func imgSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("img-src \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func manifestSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("manifest-src \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func mediaSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("media-src \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func objectSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("object-src \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func pluginTypes(types: String...) -> ContentSecurityPolicy {
+        policy.append("plugin-types \(types.joined(separator: " "))")
+        return self
+    }
+
+    func requireSriFor(values: String...) -> ContentSecurityPolicy {
+        policy.append("require-sri-for \(values.joined(separator: " "))")
+        return self
+    }
+
+    func reportTo(reportToObject: CSPReportTo) -> ContentSecurityPolicy {
+        let encoder = JSONEncoder()
+        let data = try! encoder.encode(reportToObject)
+        guard let jsonString = String(data: data, encoding: .utf8) else { return self }
+        policy.append("report-to \(String(describing: jsonString))")
+        return self
+    }
+
+    func reportUri(uri: String) -> ContentSecurityPolicy {
+        policy.append("report-uri \(uri)")
+        return self
+    }
+
+    func sandbox(values: String...) -> ContentSecurityPolicy {
+        policy.append("sandbox \(values.joined(separator: " "))")
+        return self
+    }
+
+    func scriptSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("script-src \(sources.joined(separator: " "))")
+        return self
+    }
+    
+    func styleSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("style-src \(sources.joined(separator: " "))")
+        return self
+    }
+
+    func upgradeInsecureRequests() -> ContentSecurityPolicy {
+        policy.append("upgrade-insecure-requests")
+        return self
+    }
+
+    func workerSrc(sources: String...) -> ContentSecurityPolicy {
+        policy.append("worker-src \(sources.joined(separator: " "))")
+        return self
     }
 }

--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -2,7 +2,7 @@ import Vapor
 import Foundation
 
 public struct ContentSecurityPolicyConfiguration: SecurityHeaderConfiguration {
-
+    
     private let value: String
 
     public init(value: ContentSecurityPolicy) {
@@ -145,7 +145,7 @@ public class ContentSecurityPolicy {
 
     func reportTo(reportToObject: CSPReportTo) -> ContentSecurityPolicy {
         let encoder = JSONEncoder()
-        let data = try! encoder.encode(reportToObject)
+        guard let data = try? encoder.encode(reportToObject) else { return self }
         guard let jsonString = String(data: data, encoding: .utf8) else { return self }
         policy.append("report-to \(String(describing: jsonString))")
         return self
@@ -165,7 +165,7 @@ public class ContentSecurityPolicy {
         policy.append("script-src \(sources.joined(separator: " "))")
         return self
     }
-    
+
     func styleSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("style-src \(sources.joined(separator: " "))")
         return self

--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -5,6 +5,10 @@ public struct ContentSecurityPolicyConfiguration: SecurityHeaderConfiguration {
     
     private let value: String
 
+    public init(value: String) {
+        self.value = value
+    }
+
     public init(value: ContentSecurityPolicy) {
         self.value = value.value
     }

--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -2,7 +2,6 @@ import Vapor
 import Foundation
 
 public struct ContentSecurityPolicyConfiguration: SecurityHeaderConfiguration {
-    
     private let value: String
 
     public init(value: String) {
@@ -66,6 +65,9 @@ public struct CSPReportToEndpoint: Codable {
         self.url = url
     }
 }
+
+extension CSPReportToEndpoint: Equatable {}
+extension CSPReportTo: Equatable {}
 
 public struct CSPKeywords {
     public static let all = "*"
@@ -196,6 +198,6 @@ public class ContentSecurityPolicy {
         policy.append("worker-src \(sources.joined(separator: " "))")
         return self
     }
-    
+
     public init() {}
 }

--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -68,82 +68,82 @@ public class ContentSecurityPolicy {
         return policy.joined(separator: "; ")
     }
 
-    func set(value: String) -> ContentSecurityPolicy {
+    public func set(value: String) -> ContentSecurityPolicy {
         policy.append(value)
         return self
     }
 
-    func baseUri(sources: String...) -> ContentSecurityPolicy {
+    public func baseUri(sources: String...) -> ContentSecurityPolicy {
         policy.append("base-uri \(sources.joined(separator: " "))")
         return self
     }
 
-    func blockAllMixedContent() -> ContentSecurityPolicy {
+    public func blockAllMixedContent() -> ContentSecurityPolicy {
         policy.append("block-all-mixed-content")
         return self
     }
 
-    func connectSrc(sources: String...) -> ContentSecurityPolicy {
+    public func connectSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("connect-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func defaultSrc(sources: String...) -> ContentSecurityPolicy {
+    public func defaultSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("default-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func fontSrc(sources: String...) -> ContentSecurityPolicy {
+    public func fontSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("font-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func formAction(sources: String...) -> ContentSecurityPolicy {
+    public func formAction(sources: String...) -> ContentSecurityPolicy {
         policy.append("form-action \(sources.joined(separator: " "))")
         return self
     }
 
-    func frameAncestors(sources: String...) -> ContentSecurityPolicy {
+    public func frameAncestors(sources: String...) -> ContentSecurityPolicy {
         policy.append("frame-ancestors \(sources.joined(separator: " "))")
         return self
     }
 
-    func frameSrc(sources: String...) -> ContentSecurityPolicy {
+    public func frameSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("frame-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func imgSrc(sources: String...) -> ContentSecurityPolicy {
+    public func imgSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("img-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func manifestSrc(sources: String...) -> ContentSecurityPolicy {
+    public func manifestSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("manifest-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func mediaSrc(sources: String...) -> ContentSecurityPolicy {
+    public func mediaSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("media-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func objectSrc(sources: String...) -> ContentSecurityPolicy {
+    public func objectSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("object-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func pluginTypes(types: String...) -> ContentSecurityPolicy {
+    public func pluginTypes(types: String...) -> ContentSecurityPolicy {
         policy.append("plugin-types \(types.joined(separator: " "))")
         return self
     }
 
-    func requireSriFor(values: String...) -> ContentSecurityPolicy {
+    public func requireSriFor(values: String...) -> ContentSecurityPolicy {
         policy.append("require-sri-for \(values.joined(separator: " "))")
         return self
     }
 
-    func reportTo(reportToObject: CSPReportTo) -> ContentSecurityPolicy {
+    public func reportTo(reportToObject: CSPReportTo) -> ContentSecurityPolicy {
         let encoder = JSONEncoder()
         guard let data = try? encoder.encode(reportToObject) else { return self }
         guard let jsonString = String(data: data, encoding: .utf8) else { return self }
@@ -151,33 +151,35 @@ public class ContentSecurityPolicy {
         return self
     }
 
-    func reportUri(uri: String) -> ContentSecurityPolicy {
+    public func reportUri(uri: String) -> ContentSecurityPolicy {
         policy.append("report-uri \(uri)")
         return self
     }
 
-    func sandbox(values: String...) -> ContentSecurityPolicy {
+    public func sandbox(values: String...) -> ContentSecurityPolicy {
         policy.append("sandbox \(values.joined(separator: " "))")
         return self
     }
 
-    func scriptSrc(sources: String...) -> ContentSecurityPolicy {
+    public func scriptSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("script-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func styleSrc(sources: String...) -> ContentSecurityPolicy {
+    public func styleSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("style-src \(sources.joined(separator: " "))")
         return self
     }
 
-    func upgradeInsecureRequests() -> ContentSecurityPolicy {
+    public func upgradeInsecureRequests() -> ContentSecurityPolicy {
         policy.append("upgrade-insecure-requests")
         return self
     }
 
-    func workerSrc(sources: String...) -> ContentSecurityPolicy {
+    public func workerSrc(sources: String...) -> ContentSecurityPolicy {
         policy.append("worker-src \(sources.joined(separator: " "))")
         return self
     }
+    
+    public init() {}
 }

--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -66,8 +66,20 @@ public struct CSPReportToEndpoint: Codable {
     }
 }
 
-extension CSPReportToEndpoint: Equatable {}
-extension CSPReportTo: Equatable {}
+extension CSPReportToEndpoint: Equatable {
+    public static func == (lhs: CSPReportToEndpoint, rhs: CSPReportToEndpoint) -> Bool {
+        return lhs.url == rhs.url
+    }
+}
+
+extension CSPReportTo: Equatable {
+    public static func == (lhs: CSPReportTo, rhs: CSPReportTo) -> Bool {
+        return lhs.group == rhs.group &&
+            lhs.max_age == rhs.max_age &&
+            lhs.endpoints == rhs.endpoints &&
+            lhs.include_subdomains == rhs.include_subdomains
+    }
+}
 
 public struct CSPKeywords {
     public static let all = "*"

--- a/Sources/VaporSecurityHeaders/SecurityHeaders.swift
+++ b/Sources/VaporSecurityHeaders/SecurityHeaders.swift
@@ -6,7 +6,7 @@ public struct SecurityHeaders {
     var configurations: [SecurityHeaderConfiguration]
 
     init(contentTypeConfiguration: ContentTypeOptionsConfiguration = ContentTypeOptionsConfiguration(option: .nosniff),
-         contentSecurityPolicyConfiguration: ContentSecurityPolicyConfiguration = ContentSecurityPolicyConfiguration(value: "default-src 'self'"),
+         contentSecurityPolicyConfiguration: ContentSecurityPolicyConfiguration = ContentSecurityPolicyConfiguration(value: ContentSecurityPolicy().defaultSrc(sources: CSPKeywords.`self`)),
          frameOptionsConfiguration: FrameOptionsConfiguration = FrameOptionsConfiguration(option: .deny),
          xssProtectionConfiguration: XSSProtectionConfiguration = XSSProtectionConfiguration(option: .block),
          hstsConfiguration: StrictTransportSecurityConfiguration? = nil,

--- a/Sources/VaporSecurityHeaders/SecurityHeadersFactory.swift
+++ b/Sources/VaporSecurityHeaders/SecurityHeadersFactory.swift
@@ -2,7 +2,7 @@ import Vapor
 
 public class SecurityHeadersFactory {
     var contentTypeOptions = ContentTypeOptionsConfiguration(option: .nosniff)
-    var contentSecurityPolicy = ContentSecurityPolicyConfiguration(value: "default-src 'self'")
+    var contentSecurityPolicy = ContentSecurityPolicyConfiguration(value: ContentSecurityPolicy().defaultSrc(sources: CSPKeywords.`self`))
     var frameOptions = FrameOptionsConfiguration(option: .deny)
     var xssProtection = XSSProtectionConfiguration(option: .block)
     var hsts: StrictTransportSecurityConfiguration?
@@ -14,7 +14,7 @@ public class SecurityHeadersFactory {
 
     public static func api() -> SecurityHeadersFactory {
         let apiFactory = SecurityHeadersFactory()
-        apiFactory.contentSecurityPolicy = ContentSecurityPolicyConfiguration(value: "default-src 'none'")
+        apiFactory.contentSecurityPolicy = ContentSecurityPolicyConfiguration(value: ContentSecurityPolicy().defaultSrc(sources: CSPKeywords.none))
         return apiFactory
     }
 

--- a/Tests/VaporSecurityHeadersTests/HeaderTests.swift
+++ b/Tests/VaporSecurityHeadersTests/HeaderTests.swift
@@ -348,7 +348,7 @@ class HeaderTests: XCTestCase {
     }
 
     func testHeadersWithExhaustiveCSP() throws {
-        let csp = "base-uri 'self'; frame-ancestors 'none'; frame-src 'self'; manifest-src https://brokenhands.io; object-src 'self'; plugin-types application/pdf; report-uri https://csp-report.brokenhands.io; sandbox allow-forms allow-scripts; worker-src https://brokenhands.io"
+        let csp = "base-uri 'self'; frame-ancestors 'none'; frame-src 'self'; manifest-src https://brokenhands.io; object-src 'self'; plugin-types application/pdf; report-uri https://csp-report.brokenhands.io; sandbox allow-forms allow-scripts; worker-src https://brokenhands.io; media-src https://brokenhands.io"
         let cspBuilder = ContentSecurityPolicy()
             .baseUri(sources: CSPKeywords.`self`)
             .frameAncestors(sources: CSPKeywords.none)
@@ -358,6 +358,7 @@ class HeaderTests: XCTestCase {
             .pluginTypes(types: "application/pdf")
             .reportUri(uri: "https://csp-report.brokenhands.io").sandbox(values: "allow-forms", "allow-scripts")
             .workerSrc(sources: "https://brokenhands.io")
+            .mediaSrc(sources: "https://brokenhands.io")
         let cspConfig = ContentSecurityPolicyConfiguration(value: cspBuilder)
         let factory = SecurityHeadersFactory().with(contentSecurityPolicy: cspConfig)
         let response = try makeTestResponse(for: request, securityHeadersToAdd: factory)


### PR DESCRIPTION
- Enhance the configuration of the Content Security Policy header
- Add CSP Keywords
- Add `Report-To` Directive

```swift
let cspConfig = ContentSecurityPolicy()
        .defaultSrc(sources: CSPKeywords.none)
        .scriptSrc(sources: "https://static.brokenhands.io")
        .styleSrc(sources: "https://static.brokenhands.io")
        .imgSrc(sources: "https://static.brokenhands.io")
        .fontSrc(sources: "https://static.brokenhands.io")
        .connectSrc(sources: "https://*.brokenhands.io")
        .formAction(sources: CSPKeywords.`self`)
        .upgradeInsecureRequests()
        .blockAllMixedContent()
        .requireSriFor(values: "script", "style")
        .reportUri(uri: "https://csp-report.brokenhands.io")
        
let securityHeaders = SecurityHeaders(contentSecurityPolicyConfiguration: cspConfig)
```

```http
Content-Security-Policy: default-src 'none'; script-src https://static.brokenhands.io; style-src https://static.brokenhands.io; img-src https://static.brokenhands.io; font-src https://static.brokenhands.io; connect-src https://*.brokenhands.io; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content; require-sri-for script style; report-uri https://csp-report.brokenhands.io
```