### PR TITLE
Supporting [String]

### DIFF
--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -100,7 +100,13 @@ public class ContentSecurityPolicy {
     
     @discardableResult
     public func baseUri(sources: String...) -> ContentSecurityPolicy {
-        policy.append("base-uri \(sources.joined(separator: " "))")
+        join(sources: sources, to: "base-uri")
+        return self
+    }
+    
+    @discardableResult
+    public func baseUri(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "base-uri")
         return self
     }
 
@@ -112,79 +118,157 @@ public class ContentSecurityPolicy {
     
     @discardableResult
     public func childSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("child-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "child-src")
+        return self
+    }
+    
+    @discardableResult
+    public func childSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "child-src")
         return self
     }
 
     @discardableResult
     public func connectSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("connect-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "connect-src")
+        return self
+    }
+    
+    @discardableResult
+    public func connectSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "connect-src")
         return self
     }
 
     @discardableResult
     public func defaultSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("default-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "default-src")
+        return self
+    }
+    
+    @discardableResult
+    public func defaultSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "default-src")
         return self
     }
 
     @discardableResult
     public func fontSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("font-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "font-src")
+        return self
+    }
+    
+    @discardableResult
+    public func fontSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "font-src")
         return self
     }
 
     @discardableResult
     public func formAction(sources: String...) -> ContentSecurityPolicy {
-        policy.append("form-action \(sources.joined(separator: " "))")
+        join(sources: sources, to: "form-action")
+        return self
+    }
+    
+    @discardableResult
+    public func formAction(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "form-action")
         return self
     }
 
     @discardableResult
     public func frameAncestors(sources: String...) -> ContentSecurityPolicy {
-        policy.append("frame-ancestors \(sources.joined(separator: " "))")
+        join(sources: sources, to: "frame-ancestors")
+        return self
+    }
+    
+    @discardableResult
+    public func frameAncestors(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "frame-ancestors")
         return self
     }
 
     @discardableResult
     public func frameSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("frame-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "frame-src")
+        return self
+    }
+    
+    @discardableResult
+    public func frameSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "frame-src")
         return self
     }
 
     @discardableResult
     public func imgSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("img-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "img-src")
+        return self
+    }
+    
+    @discardableResult
+    public func imgSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "img-src")
         return self
     }
 
     @discardableResult
     public func manifestSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("manifest-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "manifest-src")
+        return self
+    }
+    
+    @discardableResult
+    public func manifestSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "manifest-src")
         return self
     }
 
     @discardableResult
     public func mediaSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("media-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "media-src")
+        return self
+    }
+    
+    @discardableResult
+    public func mediaSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "media-src")
         return self
     }
 
     @discardableResult
     public func objectSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("object-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "object-src")
+        return self
+    }
+    
+    @discardableResult
+    public func objectSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "object-src")
         return self
     }
 
     @discardableResult
     public func pluginTypes(types: String...) -> ContentSecurityPolicy {
-        policy.append("plugin-types \(types.joined(separator: " "))")
+        join(sources: sources, to: "plugin-types")
+        return self
+    }
+    
+    @discardableResult
+    public func pluginTypes(types: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "plugin-types")
         return self
     }
 
     @discardableResult
     public func requireSriFor(values: String...) -> ContentSecurityPolicy {
-        policy.append("require-sri-for \(values.joined(separator: " "))")
+        join(sources: sources, to: "require-sri-for")
+        return self
+    }
+    
+    @discardableResult
+    public func requireSriFor(values: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "require-sri-for")
         return self
     }
 
@@ -205,19 +289,37 @@ public class ContentSecurityPolicy {
 
     @discardableResult
     public func sandbox(values: String...) -> ContentSecurityPolicy {
-        policy.append("sandbox \(values.joined(separator: " "))")
+        join(sources: values, to: "sandbox")
+        return self
+    }
+    
+    @discardableResult
+    public func sandbox(values: [String]) -> ContentSecurityPolicy {
+        join(sources: values, to: "sandbox")
         return self
     }
 
     @discardableResult
     public func scriptSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("script-src \(sources.joined(separator: " "))")
+        join(sources: values, to: "script-src")
+        return self
+    }
+    
+    @discardableResult
+    public func scriptSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: values, to: "script-src")
         return self
     }
 
     @discardableResult
     public func styleSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("style-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "style-src")
+        return self
+    }
+    
+    @discardableResult
+    public func styleSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "style-src")
         return self
     }
 
@@ -229,9 +331,23 @@ public class ContentSecurityPolicy {
 
     @discardableResult
     public func workerSrc(sources: String...) -> ContentSecurityPolicy {
-        policy.append("worker-src \(sources.joined(separator: " "))")
+        join(sources: sources, to: "worker-src")
+        return self
+    }
+    
+    @discardableResult
+    public func workerSrc(sources: [String]) -> ContentSecurityPolicy {
+        join(sources: sources, to: "worker-src")
         return self
     }
 
+    private func join(sources: [String], to directive: String) {
+        policy.append("\(directive) \(sources.joined(separator: " "))")
+    }
+    
+    private func join(sources: String..., to directive: String) {
+        policy.append("\(directive) \(sources.joined(separator: " "))")
+    }
+    
     public init() {}
 }

--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -345,9 +345,5 @@ public class ContentSecurityPolicy {
         policy.append("\(directive) \(sources.joined(separator: " "))")
     }
     
-    private func join(sources: String..., to directive: String) {
-        policy.append("\(directive) \(sources.joined(separator: " "))")
-    }
-    
     public init() {}
 }

--- a/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ContentSecurityPolicyConfiguration.swift
@@ -250,25 +250,25 @@ public class ContentSecurityPolicy {
 
     @discardableResult
     public func pluginTypes(types: String...) -> ContentSecurityPolicy {
-        join(sources: sources, to: "plugin-types")
+        join(sources: types, to: "plugin-types")
         return self
     }
     
     @discardableResult
     public func pluginTypes(types: [String]) -> ContentSecurityPolicy {
-        join(sources: sources, to: "plugin-types")
+        join(sources: types, to: "plugin-types")
         return self
     }
 
     @discardableResult
     public func requireSriFor(values: String...) -> ContentSecurityPolicy {
-        join(sources: sources, to: "require-sri-for")
+        join(sources: values, to: "require-sri-for")
         return self
     }
     
     @discardableResult
     public func requireSriFor(values: [String]) -> ContentSecurityPolicy {
-        join(sources: sources, to: "require-sri-for")
+        join(sources: values, to: "require-sri-for")
         return self
     }
 
@@ -301,13 +301,13 @@ public class ContentSecurityPolicy {
 
     @discardableResult
     public func scriptSrc(sources: String...) -> ContentSecurityPolicy {
-        join(sources: values, to: "script-src")
+        join(sources: sources, to: "script-src")
         return self
     }
     
     @discardableResult
     public func scriptSrc(sources: [String]) -> ContentSecurityPolicy {
-        join(sources: values, to: "script-src")
+        join(sources: sources, to: "script-src")
         return self
     }
 


### PR DESCRIPTION
The right configuration supports only String...
But in the case where I have to prepare SecurityHeadersFactory with a bit different configs, I can just prepare an array variable and increase it without duplicates for e.g.:

``` 
 let cspBuilder = ContentSecurityPolicy()
            .defaultSrc(sources: CSPKeywords.`self`)
            .styleSrc(sources: "https://developer.api.autodesk.com",
                      CSPKeywords.`self`)
            .scriptSrc(sources: "https://developer.api.autodesk.com",
                       CSPKeywords.`self`,
                       "https://www.google.com/recaptcha/",
                       "https://www.gstatic.com/recaptcha/",
                       "https://apis.google.com/js/")
            .frameSrc(sources: "https://www.google.com/recaptcha/",
                      "https://recaptcha.google.com/recaptcha/")
            .imgSrc(sources: CSPKeywords.`self`, "https://lh3.googleusercontent.com/")
        let cspConfig = ContentSecurityPolicyConfiguration(value: cspBuilder)
        securityHeadersFactory = SecurityHeadersFactory().with(contentSecurityPolicy: cspConfig)
and routes group with:
 let dashboardCSPBuilder = ContentSecurityPolicy()
            .defaultSrc(sources: CSPKeywords.`self`)
            .styleSrc(sources: "https://developer.api.autodesk.com",
                      CSPKeywords.`self`,
                      CSPKeywords.unsafeInline)
            .scriptSrc(sources: "https://developer.api.autodesk.com",
                       CSPKeywords.`self`,
                       "https://www.google.com/recaptcha/",
                       "https://www.gstatic.com/recaptcha/",
                       "https://apis.google.com/js/")
            .frameSrc(sources: "https://www.google.com/recaptcha/",
                      "https://recaptcha.google.com/recaptcha/")
            .imgSrc(sources: CSPKeywords.`self`, "https://lh3.googleusercontent.com/")
        
        let dashboardCSPConfig = ContentSecurityPolicyConfiguration(value: dashboardCSPBuilder)
        dashboardSecurityHeadersFactory = SecurityHeadersFactory().with(contentSecurityPolicy: dashboardCSPConfig)
```

the difference only in: `CSPKeywords.unsafeInline` but I have to repeat everything else. 
Using arrays like an arguments we can simple add to variable and re-use/increase it.