### PR TITLE
Add support for fallback referrer policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,3 +490,15 @@ let securityHeadersFactory = SecurityHeadersFactory().with(referrerPolicy: refer
 ```http
 referrer-policy: no-referrer
 ```
+
+You can also [set a fallback policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#specify_a_fallback_policy).
+
+```swift
+let referrerPolicyConfig = ReferrerPolicyConfiguration([.noReferrer, .strictOriginWhenCrossOrigin])
+
+let securityHeadersFactory = SecurityHeadersFactory().with(referrerPolicy: referrerPolicyConfig)
+```
+
+```http
+referrer-policy: no-referrer, strict-origin-when-cross-origin
+```

--- a/Sources/VaporSecurityHeaders/Configurations/ReferrerPolicyConfiguration.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/ReferrerPolicyConfiguration.swift
@@ -2,7 +2,7 @@ import Vapor
 
 public struct ReferrerPolicyConfiguration: SecurityHeaderConfiguration {
 
-    public enum Options: String {
+    public enum Directive: String {
         case empty = ""
         case noReferrer = "no-referrer"
         case noReferrerWhenDowngrade = "no-referrer-when-downgrade"
@@ -14,13 +14,17 @@ public struct ReferrerPolicyConfiguration: SecurityHeaderConfiguration {
         case unsafeUrl = "unsafe-url"
     }
 
-    private let option: Options
+    private let directives: [Directive]
 
-    public init(_ option: Options) {
-        self.option = option
+    public init(_ directive: Directive) {
+        self.directives = [directive]
+    }
+
+    public init(_ directives: [Directive]) {
+        self.directives = directives
     }
 
     func setHeader(on response: Response, from request: Request) {
-        response.headers.replaceOrAdd(name: .referrerPolicy, value: option.rawValue)
+        response.headers.replaceOrAdd(name: .referrerPolicy, value: directives.map({ $0.rawValue }).joined(separator: ", "))
     }
 }

--- a/Tests/VaporSecurityHeadersTests/HeaderTests.swift
+++ b/Tests/VaporSecurityHeadersTests/HeaderTests.swift
@@ -457,6 +457,14 @@ class HeaderTests: XCTestCase {
         XCTAssertEqual(expected, response.headers[.referrerPolicy].first)
     }
 
+    func testHeadersWithReferrerPolicyFallbacks() throws {
+        let expected = "no-referrer, strict-origin-when-cross-origin"
+        let referrerConfig = ReferrerPolicyConfiguration([.noReferrer, .strictOriginWhenCrossOrigin])
+        let factory = SecurityHeadersFactory().with(referrerPolicy: referrerConfig)
+        let response = try makeTestResponse(for: request, securityHeadersToAdd: factory)
+        XCTAssertEqual(expected, response.headers[.referrerPolicy].first)
+    }
+
     func testApiPolicyWithAddedReferrerPolicy() throws {
         let expected = "strict-origin"
         let referrerConfig = ReferrerPolicyConfiguration(.strictOrigin)


### PR DESCRIPTION
The `Referrer-Policy` header [supports fallback policies][0]. This adds support for that in this package!

Feel free to reject if this is unwelcome.

[0]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#specify_a_fallback_policy