### PR TITLE
Add Allowed Hosts to HTTPSRedirectMiddleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,21 +3,14 @@ on:
   push:
   pull_request:
 jobs:
-  xenial:
+  test:
     container: 
-      image: vapor/swift:5.2-xenial
+      image: swift:5.8
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - run: swift test --enable-test-discovery --enable-code-coverage --sanitize=thread
-  bionic:
-    container: 
-      image: vapor/swift:5.2-bionic
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Run Bionic Tests
-      run: swift test --enable-test-discovery --enable-code-coverage --sanitize=thread
+    - uses: actions/checkout@v3
+    - name: Run Tests
+      run: swift test --enable-code-coverage --sanitize=thread
     - name: Setup container for codecov upload
       run: apt-get update && apt-get install curl -y
     - name: Process coverage file

--- a/README.md
+++ b/README.md
@@ -413,6 +413,14 @@ To use the HTTPS Redirect Middleware, you can add the following line in **config
 app.middleware.use(HTTPSRedirectMiddleware())
 ```
 
+The `HTTPSRedirectMiddleware` allows you to set an array of allowed hosts that the application can redirect to. This prevents attackers poisoning the `Host` header and forcing a redirect to a domain under their control. To use this, provide the list of allowed hosts to the initialiser:
+
+```swift
+app.middleware.use(HTTPSRedirectMiddleware(allowedHosts: ["www.brokenhands.io", "brokenhands.io", "static.brokenhands.io"))
+```
+
+Any attempts to redirect to another host, for example `attacker.com` will result in a **400 Bad Request** response.
+
 ## Server
 
 The Server header is usually hidden from responses in order to not give away what type of server you are running and what version you are using. This is to stop attackers from scanning your site and using known vulnerabilities against it easily. By default Vapor does not show the server header in responses for this reason.

--- a/Sources/VaporSecurityHeaders/Configurations/HTTPSRedirectMiddleware.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/HTTPSRedirectMiddleware.swift
@@ -18,7 +18,7 @@ public class HTTPSRedirectMiddleware: Middleware {
                 return request.eventLoop.makeFailedFuture(Abort(.badRequest))
             }
             let httpsURL = "https://" + host + "\(request.url)"
-            return request.redirect(to: "\(httpsURL)", type: .permanent).encodeResponse(for: request)
+            return request.redirect(to: "\(httpsURL)", redirectType: .permanent).encodeResponse(for: request)
         }
         return next.respond(to: request)
     }

--- a/Sources/VaporSecurityHeaders/Configurations/HTTPSRedirectMiddleware.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/HTTPSRedirectMiddleware.swift
@@ -2,9 +2,9 @@ import Vapor
 
 public class HTTPSRedirectMiddleware: Middleware {
 
-    let allowedHosts: [String]
+    let allowedHosts: [String]?
     
-    public init(allowedHosts: [String] = []) {
+    public init(allowedHosts: [String]? = nil) {
         self.allowedHosts = allowedHosts
     }
     
@@ -21,6 +21,13 @@ public class HTTPSRedirectMiddleware: Middleware {
             guard let host = request.headers.first(name: .host) else {
                 return request.eventLoop.makeFailedFuture(Abort(.badRequest))
             }
+            
+            if let allowedHosts = allowedHosts {
+                guard allowedHosts.contains(host) else {
+                    return request.eventLoop.makeFailedFuture(Abort(.badRequest))
+                }
+            }
+            
             let httpsURL = "https://" + host + "\(request.url)"
             return request.redirect(to: "\(httpsURL)", redirectType: .permanent).encodeResponse(for: request)
         }

--- a/Sources/VaporSecurityHeaders/Configurations/HTTPSRedirectMiddleware.swift
+++ b/Sources/VaporSecurityHeaders/Configurations/HTTPSRedirectMiddleware.swift
@@ -2,7 +2,11 @@ import Vapor
 
 public class HTTPSRedirectMiddleware: Middleware {
 
-    public init() {}
+    let allowedHosts: [String]
+    
+    public init(allowedHosts: [String] = []) {
+        self.allowedHosts = allowedHosts
+    }
     
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         if request.application.environment == .development {

--- a/Tests/VaporSecurityHeadersTests/RedirectionTest.swift
+++ b/Tests/VaporSecurityHeadersTests/RedirectionTest.swift
@@ -40,6 +40,7 @@ class RedirectionTest: XCTestCase {
     func testWithRedirectMiddlewareWithDisallowedHost() throws {
         let expectedOutcome: String = "Abort.400: Bad Request"
         do {
+            request.headers.add(name: .host, value: "localhost:8080")
             _ = try makeTestResponse(for: request, withRedirection: true, allowedHosts: ["localhost:8081", "example.com"])
         } catch (let error) {
             XCTAssertEqual(expectedOutcome, error.localizedDescription)

--- a/Tests/VaporSecurityHeadersTests/RedirectionTest.swift
+++ b/Tests/VaporSecurityHeadersTests/RedirectionTest.swift
@@ -33,15 +33,17 @@ class RedirectionTest: XCTestCase {
     func testWithRedirectMiddlewareWithAllowedHost() throws {
         let expectedRedirectStatus: HTTPStatus = HTTPResponseStatus(statusCode: 301, reasonPhrase: "Moved permanently")
         request.headers.add(name: .host, value: "localhost:8080")
-        let responseRedirected = try makeTestResponse(for: request, withRedirection: true, allowedHosts: ["localhost:8081", "example.com"])
+        let responseRedirected = try makeTestResponse(for: request, withRedirection: true, allowedHosts: ["localhost:8080", "example.com"])
         XCTAssertEqual(expectedRedirectStatus, responseRedirected.status)
     }
     
     func testWithRedirectMiddlewareWithDisallowedHost() throws {
-        let expectedRedirectStatus: HTTPStatus = HTTPResponseStatus(statusCode: 400, reasonPhrase: "Bad request")
-        request.headers.add(name: .host, value: "localhost:8080")
-        let responseRedirected = try makeTestResponse(for: request, withRedirection: true, allowedHosts: ["localhost:8081", "example.com"])
-        XCTAssertEqual(expectedRedirectStatus, responseRedirected.status)
+        let expectedOutcome: String = "Abort.400: Bad Request"
+        do {
+            _ = try makeTestResponse(for: request, withRedirection: true, allowedHosts: ["localhost:8081", "example.com"])
+        } catch (let error) {
+            XCTAssertEqual(expectedOutcome, error.localizedDescription)
+        }
     }
     
     func testWithoutRedirectionMiddleware() throws {
@@ -74,7 +76,7 @@ class RedirectionTest: XCTestCase {
         XCTAssertEqual(expectedStatus, response.status)
     }
     
-    private func makeTestResponse(for request: Request, withRedirection: Bool, environment: Environment? = nil, allowedHosts: [String] = []) throws -> Response {
+    private func makeTestResponse(for request: Request, withRedirection: Bool, environment: Environment? = nil, allowedHosts: [String]? = nil) throws -> Response {
         application.middleware = Middlewares()
         if let environment = environment {
             application.environment = environment


### PR DESCRIPTION
Adds a new parameter to `HTTPSRedirectMiddleware` to allow users to set allowed hosts that can be redirected to. Prevents attackers poisoning the host header to force redirects to their domains.

Resolves #28 