### PR TITLE
Allow setting no XSS header

### DIFF
--- a/Sources/VaporSecurityHeaders/SecurityHeaders.swift
+++ b/Sources/VaporSecurityHeaders/SecurityHeaders.swift
@@ -7,13 +7,17 @@ public struct SecurityHeaders {
     init(contentTypeConfiguration: ContentTypeOptionsConfiguration = ContentTypeOptionsConfiguration(option: .nosniff),
          contentSecurityPolicyConfiguration: ContentSecurityPolicyConfiguration = ContentSecurityPolicyConfiguration(value: ContentSecurityPolicy().defaultSrc(sources: CSPKeywords.`self`)),
          frameOptionsConfiguration: FrameOptionsConfiguration = FrameOptionsConfiguration(option: .deny),
-         xssProtectionConfiguration: XSSProtectionConfiguration = XSSProtectionConfiguration(),
+         xssProtectionConfiguration: XSSProtectionConfiguration? = XSSProtectionConfiguration(),
          hstsConfiguration: StrictTransportSecurityConfiguration? = nil,
          serverConfiguration: ServerConfiguration? = nil,
          contentSecurityPolicyReportOnlyConfiguration: ContentSecurityPolicyReportOnlyConfiguration? = nil,
          referrerPolicyConfiguration: ReferrerPolicyConfiguration? = nil) {
-        configurations = [contentTypeConfiguration, contentSecurityPolicyConfiguration, frameOptionsConfiguration, xssProtectionConfiguration]
+        configurations = [contentTypeConfiguration, contentSecurityPolicyConfiguration, frameOptionsConfiguration]
 
+        if let xssProtectionConfiguration {
+            configurations.append(xssProtectionConfiguration)
+        }
+        
         if let hstsConfiguration = hstsConfiguration {
             configurations.append(hstsConfiguration)
         }

--- a/Sources/VaporSecurityHeaders/SecurityHeadersFactory.swift
+++ b/Sources/VaporSecurityHeaders/SecurityHeadersFactory.swift
@@ -4,7 +4,7 @@ public class SecurityHeadersFactory {
     var contentTypeOptions = ContentTypeOptionsConfiguration(option: .nosniff)
     var contentSecurityPolicy = ContentSecurityPolicyConfiguration(value: ContentSecurityPolicy().defaultSrc(sources: CSPKeywords.`self`))
     var frameOptions = FrameOptionsConfiguration(option: .deny)
-    var xssProtection = XSSProtectionConfiguration()
+    var xssProtection: XSSProtectionConfiguration? = XSSProtectionConfiguration()
     var hsts: StrictTransportSecurityConfiguration?
     var server: ServerConfiguration?
     var referrerPolicy: ReferrerPolicyConfiguration?
@@ -33,7 +33,7 @@ public class SecurityHeadersFactory {
         return self
     }
 
-    @discardableResult public func with(XSSProtection configuration: XSSProtectionConfiguration) -> SecurityHeadersFactory {
+    @discardableResult public func with(XSSProtection configuration: XSSProtectionConfiguration?) -> SecurityHeadersFactory {
         xssProtection = configuration
         return self
     }

--- a/Tests/VaporSecurityHeadersTests/HeaderTests.swift
+++ b/Tests/VaporSecurityHeadersTests/HeaderTests.swift
@@ -140,6 +140,13 @@ class HeaderTests: XCTestCase {
 
         XCTAssertEqual("0", response.headers[.xssProtection].first)
     }
+    
+    func testHeaderWithXssProtectionDisabled() throws {
+        let factory = SecurityHeadersFactory().with(XSSProtection: nil)
+        let response = try makeTestResponse(for: request, securityHeadersToAdd: factory)
+
+        XCTAssertNil(response.headers[.xssProtection].first)
+    }
 
     func testHeaderWithHSTSwithMaxAge() throws {
         let hstsConfig = StrictTransportSecurityConfiguration(maxAge: 30)


### PR DESCRIPTION
Currently the XSS header is hardcoded and cannot be removed. 

From a recent pentest against our Vapor server, it was recommended to remove the XSS header for the following reason:

>  This leaves any application using the APIs vulnerable to cross site scripting in browsers which do not support CSP. It is recommended to remove X-XSS protection completely and rely on a secure CSP.

OWASP also [recommends this](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection):
> Do not set this header or explicitly turn it off. 

So this change allows the XSS configuration to be removed to align with these recommendations.